### PR TITLE
Remove extra quote in bash invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-
     - run: npm ci
     - run: npm run build
-
+    - run: |
+        git clone --depth=1 --branch=0.8.1 \
+            https://github.com/ament/ament_lint.git
     - uses: ros-tooling/setup-ros2@0.0.3
     - uses: ./ # Uses an action in the root directory
       with:
         package-name: ament_copyright ament_lint
+        workspace-directory: ament_lint

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
         Passing multiple package names is allowed.
         Package names can be separated by any whitespace character.
     required: true
+  workspace-directory:
+    description: Linters will look for packages in this colcon workspace
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -973,9 +973,9 @@ function run() {
             console.log(`##[add-matcher]${path.join(matchersPath, "ament_flake8.json")}`);
             const linterTool = core.getInput("linter");
             const packageName = core.getInput("package-name", { required: true });
-            const packageNameList = packageName.split(RegExp('\\s'));
+            const packageNameList = packageName.split(RegExp("\\s"));
             const ros2Distribution = core.getInput("distribution");
-            const ros2WorkspaceDir = process.env.GITHUB_WORKSPACE;
+            const ros2WorkspaceDir = core.getInput("workspace-directory") || process.env.GITHUB_WORKSPACE;
             yield exec.exec("rosdep", ["update"]);
             yield runAptGetInstall([`ros-${ros2Distribution}-ament-${linterTool}`]);
             const options = {
@@ -987,7 +987,7 @@ function run() {
             yield exec.exec("bash", [
                 "-c",
                 `source /opt/ros/${ros2Distribution}/setup.sh && ` +
-                    `ament_${linterTool} "$(colcon list --packages-select '${packageNameList.join(' ')}' -p)"`
+                    `ament_${linterTool} $(colcon list --packages-select ${packageNameList.join(" ")} -p)`
             ], options);
         }
         catch (error) {

--- a/src/action-ros2-lint.ts
+++ b/src/action-ros2-lint.ts
@@ -31,7 +31,8 @@ async function run() {
 		const packageName = core.getInput("package-name", { required: true });
 		const packageNameList = packageName.split(RegExp("\\s"));
 		const ros2Distribution = core.getInput("distribution");
-		const ros2WorkspaceDir = process.env.GITHUB_WORKSPACE;
+		const ros2WorkspaceDir =
+			core.getInput("workspace-directory") || process.env.GITHUB_WORKSPACE;
 
 		await exec.exec("rosdep", ["update"]);
 
@@ -49,9 +50,9 @@ async function run() {
 			[
 				"-c",
 				`source /opt/ros/${ros2Distribution}/setup.sh && ` +
-					`ament_${linterTool} "$(colcon list --packages-select '${packageNameList.join(
+					`ament_${linterTool} $(colcon list --packages-select ${packageNameList.join(
 						" "
-					)}' -p)"`
+					)} -p)`
 			],
 			options
 		);


### PR DESCRIPTION
Currently, we use the following bash invokation to run the linter:

`ament_<linter> $(colcon list --packages-select 'a b c')`

The use of "colcon list" is to convert the list of package names into
packages paths that the linter expects.
I.e. we can run ament_copyright /path/to/pkg/a /path/to/pkg/b, but not
ament_copyright a b.

This fails because colcon list is looking for a single package called 'a b c'.
As there is no package called 'a b c'. What we want is instead selecting
package, "a", "b", and "c". This can be done by removing the single quotes
around the package list:

`ament_<linter> $(colcon list --packages-select a b c)`

Unfortunately, "colcon list" returns 0 (success), even if it fails to
match anything. Therefore, there is no easy way to detect this issue
with the current implementation. An alternative solution could be to
parse stderr, which is cumbersome, and brittle. For now, we chose to
only fix the issue, without introducing a test or a safety mechanism to
prevent regressions from happening.